### PR TITLE
Mark Color as Copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1550,7 +1550,7 @@ impl ColorSpec {
 ///
 /// Hexadecimal numbers are written with a `0x` prefix.
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Color {
     Black,
     Blue,


### PR DESCRIPTION
Closes #8.

1. Should any other changes happen with this, like changing any internal methods from accepting `&Color` to `Color`?
2. Should any other types be marked `Copy` besides `Color`?