### PR TITLE
Escape non-printing ANSI color codes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1221,7 +1221,7 @@ impl<W: io::Write> Ansi<W> {
                 assert!(pre_len <= 7);
                 let mut fmt = [0u8; 21];
                 fmt[0] = b'\x01';
-                fmt[1..=pre_len].copy_from_slice($pre);
+                fmt[1..pre_len+1].copy_from_slice($pre);
                 let mut i = pre_len;
                 $(
                     let c1: u8 = ($code / 100) % 10;
@@ -1247,7 +1247,7 @@ impl<W: io::Write> Ansi<W> {
 
                 fmt[i] = b'm';
                 fmt[i+1] = b'\x02';
-                self.write_all(&fmt[0..=i+1])
+                self.write_all(&fmt[0..i+2])
             }}
         }
         macro_rules! write_custom {


### PR DESCRIPTION
When calculating the line length of a user's shell prompt which has been colored using ANSI escape codes, the line length is not calculated correctly unless the non-printing characters are escaped with `'\['` and `'\]'`, or `'\x01'` and `'\x02'` respectively, surrounding the ANSI codes.

**For example:**

![bug-example](https://user-images.githubusercontent.com/14112725/48316577-89497700-e5b3-11e8-9997-fde3924b4b84.gif)

Add the `'\x01'` and `'\x02'` codes to all ANSI sequences in order to respect line-length in interactive contexts.  This _increases_ the number of bytes that must be written and thus may have some negative performance impact.