### PR TITLE
Add no_reset to ColorSpec + getter/setter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1156,7 +1156,9 @@ impl<W: io::Write> WriteColor for Ansi<W> {
 
     #[inline]
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
-        self.reset()?;
+        if !spec.no_reset {
+            self.reset()?;
+        }
         if spec.bold {
             self.write_str("\x1B[1m")?;
         }
@@ -1416,6 +1418,7 @@ pub struct ColorSpec {
     bold: bool,
     intense: bool,
     underline: bool,
+    no_reset: bool,
 }
 
 impl ColorSpec {
@@ -1465,6 +1468,19 @@ impl ColorSpec {
     /// Note that the underline setting has no effect in a Windows console.
     pub fn set_underline(&mut self, yes: bool) -> &mut ColorSpec {
         self.underline = yes;
+        self
+    }
+
+    /// Get whether no_reset is enabled or not.
+    ///
+    /// Note that the no_reset setting has no effect in a Windows console.
+    pub fn no_reset(&self) -> bool { self.no_reset }
+
+    /// Set whether to skip initial `reset` on `set_color`.
+    ///
+    /// Note that the no_reset setting has no effect in a Windows console.
+    pub fn set_no_reset(&mut self, yes: bool) -> &mut ColorSpec {
+        self.no_reset = yes;
         self
     }
 


### PR DESCRIPTION
Prevents `set_color` from automatically resetting on each invocation, and allows the user to do this manually when needed. (As discussed in #17.)

I figured the most logical place to put this is in the `ColorSpec` along with the other attributes.  If something like this makes sense, great; if not, I understand if it's a feature no one else could use.

Either way, thanks for the crate. I think it provides the most flexible and efficient means for test coloring in Rust.