### PR TITLE
wincolor: specify dual-license

### DIFF
--- a/wincolor/Cargo.toml
+++ b/wincolor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/BurntSushi/termcolor/tree/master/wincolor"
 repository = "https://github.com/BurntSushi/termcolor/tree/master/wincolor"
 readme = "README.md"
 keywords = ["windows", "win", "color", "ansi", "console"]
-license = "Unlicense/MIT"
+license = "Unlicense OR MIT"
 
 [lib]
 name = "wincolor"


### PR DESCRIPTION
The usage of `/` is deprecated: https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata.

Switch to `OR` to be SPDX compliant.