### PR TITLE
Use atty to detect color support on not-windows systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ bench = false
 
 [target.'cfg(windows)'.dependencies]
 wincolor = { version = "1", path = "wincolor" }
+
+[target.'cfg(not(windows))'.dependencies]
+atty = "0.2"

--- a/src/bin/auto.rs
+++ b/src/bin/auto.rs
@@ -1,0 +1,20 @@
+extern crate termcolor;
+
+use std::io::Write;
+
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor, BufferWriter, BufferedStandardStream};
+
+fn main() {
+    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+    stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green))).unwrap();
+    writeln!(&mut stdout, "green text!").unwrap();
+
+    let mut bss = BufferedStandardStream::stdout(ColorChoice::Auto);
+    bss.set_color(ColorSpec::new().set_fg(Some(Color::Green))).unwrap();
+    writeln!(&mut bss, "buffered text 1!").unwrap();
+
+    let buffer_writer = BufferWriter::stdout(ColorChoice::Auto);
+    let mut buffer = buffer_writer.buffer();
+    writeln!(&mut buffer, "buffered text 2!").unwrap();
+    buffer_writer.print(&buffer).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ bufwtr.print(&buffer)?;
 #[cfg(windows)]
 extern crate wincolor;
 
+#[cfg(not(windows))]
 extern crate atty;
 
 use std::env;
@@ -223,6 +224,7 @@ enum StandardStreamType {
     StderrBuffered,
 }
 
+#[cfg(not(windows))]
 impl StandardStreamType {
     fn has_color(&self) -> bool {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ bufwtr.print(&buffer)?;
 #[cfg(windows)]
 extern crate wincolor;
 
+extern crate atty;
+
 use std::env;
 use std::error;
 use std::fmt;
@@ -219,6 +221,15 @@ enum StandardStreamType {
     Stderr,
     StdoutBuffered,
     StderrBuffered,
+}
+
+impl StandardStreamType {
+    fn has_color(&self) -> bool {
+        match self {
+            StandardStreamType::Stdout | StandardStreamType::StdoutBuffered => atty::is(atty::Stream::Stdout),
+            StandardStreamType::Stderr | StandardStreamType::StderrBuffered => atty::is(atty::Stream::Stderr),
+        }
+    }
 }
 
 enum IoStandardStream {
@@ -475,7 +486,7 @@ impl WriterInner<IoStandardStream> {
         sty: StandardStreamType,
         choice: ColorChoice,
     ) -> WriterInner<IoStandardStream> {
-        if choice.should_attempt_color() {
+        if choice.should_attempt_color() && sty.has_color() {
             WriterInner::Ansi(Ansi(IoStandardStream::new(sty)))
         } else {
             WriterInner::NoColor(NoColor(IoStandardStream::new(sty)))


### PR DESCRIPTION
Currently color support detection (in *nix) is done by checking the TERM environment variable. Such a check does not, however, cover the situation where a program's output is piped to some other program for machine processing, where color codes in the output may be unwelcome.

This PR adds a dependency on the `atty` crate that is used to check whether the output destination is a TTY; color codes are disabled if it is not.

The `src/bin/auto.rs` file contains some code to help test the changes. I ran it manually like this:
```
cargo run --bin auto && cargo run --bin auto | grep text
```
The first execution should print colored text, the second one should not color its output.

I'm not sure how to set this test up in your CI environment. Neither could I test this in Windows, so the changes in code and the additional dependency is limited to non-windows configurations.