### PR TITLE
tests: remove use of doc_comment crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,6 @@ bench = false
 winapi-util = "0.1.3"
 
 [dev-dependencies]
-doc-comment = "0.3"
+# TODO: Re-enable this once the MSRV is 1.43 or greater.
+# See: https://github.com/BurntSushi/termcolor/issues/35
+# doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,10 +119,10 @@ Currently, `termcolor` does not provide anything to do this for you.
 
 #![deny(missing_docs)]
 
-#[cfg(doctest)]
-use doc_comment::doctest;
-#[cfg(doctest)]
-doctest!("../README.md");
+// #[cfg(doctest)]
+// use doc_comment::doctest;
+// #[cfg(doctest)]
+// doctest!("../README.md");
 
 use std::env;
 use std::error;


### PR DESCRIPTION
Removes the use of doc_comment for now.

Fixes #35