### PR TITLE
Implement WriteColor for std::io::Sink

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1450,6 +1450,20 @@ impl<W: io::Write> Ansi<W> {
     }
 }
 
+impl WriteColor for io::Sink {
+    fn supports_color(&self) -> bool {
+        false
+    }
+
+    fn set_color(&mut self, _: &ColorSpec) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn reset(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 /// An in-memory buffer that provides Windows console coloring.
 ///
 /// This doesn't actually communicate with the Windows console. Instead, it


### PR DESCRIPTION
This PR addresses #37 by implementing `WriteColor` for [`std::io::Sink`](https://doc.rust-lang.org/std/io/struct.Sink.html). A `Sink` is a writer which moves data into the void, and can be useful for when you want to measure the performance of a program without including I/O.