### PR TITLE
`impl {Default, FromStr} for ColorChoice`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,26 @@ pub enum ColorChoice {
     Never,
 }
 
+impl Default for ColorChoice {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+impl FromStr for ColorChoice {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "always" => Ok(Self::Always),
+            "always-ansi" => Ok(Self::AlwaysAnsi),
+            "never" => Ok(Self::Never),
+            "auto" => Ok(Self::Auto),
+            _ => Err(()),
+        }
+    }
+}
+
 impl ColorChoice {
     /// Returns true if we should attempt to write colored output.
     fn should_attempt_color(&self) -> bool {


### PR DESCRIPTION
This allows x.py in rust-lang/rust to remove a wrapper type around
ColorChoice. The defaults here seem reasonable; I chose kebab-case for
parsing `AlwaysAnsi` but I'm happy to switch it.

I am also ok with just closing this if you don't think it's a good fit, the wrapper type isn't hard to maintain.

cc https://github.com/rust-lang/rust/pull/86022