### PR TITLE
WIP: Adopt concolor-control for auto-detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,13 @@ edition = "2018"
 name = "termcolor"
 bench = false
 
+[features]
+default = ["auto"]
+auto = ["concolor-control/auto"]
+
+[dependencies]
+concolor-control = { version = "0.0.6", default-features = false }
+
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1.3"
 


### PR DESCRIPTION
This is a PoC to collect feedback on a crate meant improve
interoperability across various colored output crates.

I'm a little uncertain on the `Buffer`
- It handles `console` differently than `WriterInner`
- I used the lowest common denominator of the streams but I wonder if we
  should add support for completely skipping stream detection

For more on the motivation, see https://github.com/rust-cli/team/issues/15#issuecomment-891350115