### PR TITLE
Implement Ansi::write_all() explicitly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1287,6 +1287,11 @@ impl<W: io::Write> io::Write for Ansi<W> {
     }
 
     #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
     }


### PR DESCRIPTION
This gives a large speedup when doing small writes into an `Ansi<BufWriter<...>>`.

This example (piped to `/dev/null`) runs about twice as fast after this change:
```rust
use std::io::{stdout, BufWriter, Write};
use termcolor::Ansi;

fn main() {
    let mut out = Ansi::new(BufWriter::new(stdout()));
    let data = [b'a'; 16];
    for _ in 0..100_000_000 {
        out.write_all(&data).unwrap();
    }
}
```
The real-world code that prompted it gets an 80% speedup.

I'm guessing this has to do with `BufWriter`'s specialized `write_all` implementation.

It also has a specialized `write_vectored` implementation, but that seems a lot less important and it'd require raising the MSRV.

(`BufferedStandardStream::stdout(ColorChoice::AlwaysAnsi)` stays slow even if I add three layers of explicit `write_all` implementations.)