### PR TITLE
`serde` support for `Color` and `ColorChoice`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termcolor"
-version = "1.1.3"  #:version
+version = "1.1.3"
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 A simple cross platform library for writing colored text to a terminal.
@@ -26,3 +26,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # TODO: Re-enable this once the MSRV is 1.43 or greater.
 # See: https://github.com/BurntSushi/termcolor/issues/35
 # doc-comment = "0.3"
+
+[package.metadata.docs.rs]
+features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ bench = false
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1.3"
 
-[dev-dependencies]
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
 # TODO: Re-enable this once the MSRV is 1.43 or greater.
 # See: https://github.com/BurntSushi/termcolor/issues/35
 # doc-comment = "0.3"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Add this to your `Cargo.toml`:
 termcolor = "1.1"
 ```
 
+## Cargo Features
+
+ * `serde` – Add support for (de-)serialization of the `Color` and
+   `ColorChoice` enums.
+
 ### Organization
 
 The `WriteColor` trait extends the `io::Write` trait with methods for setting

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,12 +124,16 @@ Currently, `termcolor` does not provide anything to do this for you.
 // #[cfg(doctest)]
 // doctest!("../README.md");
 
-use std::env;
-use std::error;
-use std::fmt;
-use std::io::{self, Write};
-use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use std::{
+    env, error, fmt,
+    io::{self, Write},
+    str::FromStr,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
 #[cfg(windows)]
 use std::sync::{Mutex, MutexGuard};
 
@@ -202,8 +206,10 @@ impl<T: ?Sized + WriteColor> WriteColor for Box<T> {
     }
 }
 
+
 /// ColorChoice represents the color preferences of an end user.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ColorChoice {
     /// Try very hard to emit colors. This includes emitting ANSI colors
     /// on Windows if the console API is unavailable.
@@ -1803,6 +1809,7 @@ impl ColorSpec {
 /// Hexadecimal numbers are written with a `0x` prefix.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Color {
     Black,
     Blue,


### PR DESCRIPTION
See subject.
Also updated README (added `serde` feature flag docs).

While at it:
* Readme: `docs.rs` badge.
* Readme/docs: headline capitalization.
* Docs: intra-doc links.
* Ran `cargo fmt` (of latest `nightly`).

I tested both w/ and w/o `serde` feature on `rustc 1.34` to make sure the changes hold up to the promise made in the readme.
