### PR TITLE
bug: respect NO_COLOR env var only if set to non-empty value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,9 +243,9 @@ impl ColorChoice {
             }
         }
         // If TERM != dumb, then the only way we don't allow colors at this
-        // point is if NO_COLOR is set.
-        if env::var_os("NO_COLOR").is_some() {
-            return false;
+        // point is if NO_COLOR is set to a non-empty value.
+        if let Some(k) = env::var_os("NO_COLOR") {
+            return k.is_empty();
         }
         true
     }
@@ -261,9 +261,9 @@ impl ColorChoice {
             }
         }
         // If TERM != dumb, then the only way we don't allow colors at this
-        // point is if NO_COLOR is set.
-        if env::var_os("NO_COLOR").is_some() {
-            return false;
+        // point is if NO_COLOR is set to a non-empty value.
+        if let Some(k) = env::var_os("NO_COLOR") {
+            return k.is_empty();
         }
         true
     }


### PR DESCRIPTION
The NO_COLOR environment variable should only be honoured if the value is not empty. This means ‘export NO_COLOR=’ (or equivalent) can be used to enable color again, which is useful in environments where env vars can be added, but not unset, e.g. CI systems supporting env vars in YAML config files.

Quoting the informal ‘spec’:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present
> and not an empty string (regardless of its value), prevents the
> addition of ANSI color. – https://no-color.org/

See also #13.