### PR TITLE
Add support for hyperlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tags
 target
 /Cargo.lock
 /wincolor/Cargo.lock
+/.idea


### PR DESCRIPTION
I'd like to implement [hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) support in ripgrep (https://github.com/BurntSushi/ripgrep/issues/665), and this is the first step, as per [your comment](https://github.com/BurntSushi/ripgrep/issues/665#issuecomment-840735760) @BurntSushi.

I had to make some design choices here, which I can adjust after getting your input:

- Currently, `reset` does *not* reset the hyperlink, only the color. That's not necessarily the best choice, and I'm not sure what to do here, so I need your guidance. My reasoning was:
  - Colors and hyperlinks are cleanly split.
  - The "auto-reset" feature (`set_reset`) would get in the way, and calling `set_color` could reset the hyperlink, which would be unexpected. I could only reset the color in that case though. On the other hand, `reset` not resetting everything is also unexpected. 😕
  - The reset code would be much longer (`"\x1B[0m\x1B]8;;\x1B\\"` instead of `"\x1B[0m"`), not sure if that's an issue. Maybe that could be mitigated by adding some state in `Ansi`, so it would only emit the hyperlink reset code if previously emitted a hyperlink?

- An alternate implementation would be a `write_hyperlink` function which takes the URI *and* text to write in a single call, but that would prevent from using multiple colors in a hyperlink easily. I suppose another function which takes a closure would need to be provided in order to handle this case.

- I didn't add support for link parameters yet. These can be added later to the `HyperlinkSpec` type:
  - Either as a generic key/value map
  - Or only with support for known parameters (currently, only `id` is [defined](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#hover-underlining-and-the-id-parameter))

So, please tell me which solution you prefer and I'll implement it. 🙂 

I tested this with Windows Terminal.
