### PR TITLE
rollup: bring in several low-hanging fruit PRs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/BurntSushi/termcolor"
 readme = "README.md"
 keywords = ["windows", "win", "color", "ansi", "console"]
 license = "Unlicense OR MIT"
-exclude = ["/.travis.yml", "/appveyor.yml", "/ci/**"]
 edition = "2018"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1369,6 +1369,9 @@ impl<W: io::Write> WriteColor for Ansi<W> {
         if spec.underline {
             self.write_str("\x1B[4m")?;
         }
+        if spec.strikethrough {
+            self.write_str("\x1B[9m")?;
+        }
         if let Some(ref c) = spec.fg_color {
             self.write_color(true, c, spec.intense)?;
         }
@@ -1640,6 +1643,7 @@ pub struct ColorSpec {
     dimmed: bool,
     italic: bool,
     reset: bool,
+    strikethrough: bool,
 }
 
 impl Default for ColorSpec {
@@ -1653,6 +1657,7 @@ impl Default for ColorSpec {
             dimmed: false,
             italic: false,
             reset: true,
+            strikethrough: false,
         }
     }
 }
@@ -1745,6 +1750,21 @@ impl ColorSpec {
         self
     }
 
+    /// Get whether this is strikethrough or not.
+    ///
+    /// Note that the strikethrough setting has no effect in a Windows console.
+    pub fn strikethrough(&self) -> bool {
+        self.strikethrough
+    }
+
+    /// Set whether the text is strikethrough or not.
+    ///
+    /// Note that the strikethrough setting has no effect in a Windows console.
+    pub fn set_strikethrough(&mut self, yes: bool) -> &mut ColorSpec {
+        self.strikethrough = yes;
+        self
+    }
+
     /// Get whether reset is enabled or not.
     ///
     /// reset is enabled by default. When disabled and using ANSI escape
@@ -1806,6 +1826,7 @@ impl ColorSpec {
             && !self.dimmed
             && !self.italic
             && !self.intense
+            && !self.strikethrough
     }
 
     /// Clears this color specification so that it has no color/style settings.
@@ -1817,6 +1838,7 @@ impl ColorSpec {
         self.intense = false;
         self.dimmed = false;
         self.italic = false;
+        self.strikethrough = false;
     }
 
     /// Writes this color spec to the given Windows console.
@@ -2271,16 +2293,19 @@ mod tests {
                     for underline in vec![false, true] {
                         for intense in vec![false, true] {
                             for italic in vec![false, true] {
-                                for dimmed in vec![false, true] {
-                                    let mut color = ColorSpec::new();
-                                    color.set_fg(fg);
-                                    color.set_bg(bg);
-                                    color.set_bold(bold);
-                                    color.set_underline(underline);
-                                    color.set_intense(intense);
-                                    color.set_dimmed(dimmed);
-                                    color.set_italic(italic);
-                                    result.push(color);
+                                for strikethrough in vec![false, true] {
+                                    for dimmed in vec![false, true] {
+                                        let mut color = ColorSpec::new();
+                                        color.set_fg(fg);
+                                        color.set_bg(bg);
+                                        color.set_bold(bold);
+                                        color.set_underline(underline);
+                                        color.set_intense(intense);
+                                        color.set_italic(italic);
+                                        color.set_dimmed(dimmed);
+                                        color.set_strikethrough(strikethrough);
+                                        result.push(color);
+                                    }
                                 }
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(missing_debug_implementations)]
 /*!
 This crate provides a cross platform abstraction for writing colored text to
 a terminal. Colors are written using either ANSI escape sequences or by
@@ -110,7 +109,7 @@ let stdout = StandardStream::stdout(choice);
 Currently, `termcolor` does not provide anything to do this for you.
 */
 
-#![deny(missing_docs)]
+#![deny(missing_debug_implementations, missing_docs)]
 
 // #[cfg(doctest)]
 // use doc_comment::doctest;
@@ -958,7 +957,7 @@ impl BufferWriter {
         }
         let stream = LossyStandardStream::new(IoStandardStream::new(sty));
         BufferWriter {
-            stream: stream,
+            stream,
             printed: AtomicBool::new(false),
             separator: None,
             color_choice: choice,
@@ -2096,14 +2095,14 @@ struct LossyStandardStream<W> {
 impl<W: io::Write> LossyStandardStream<W> {
     #[cfg(not(windows))]
     fn new(wtr: W) -> LossyStandardStream<W> {
-        LossyStandardStream { wtr: wtr }
+        LossyStandardStream { wtr }
     }
 
     #[cfg(windows)]
     fn new(wtr: W) -> LossyStandardStream<W> {
         let is_console = wincon::Console::stdout().is_ok()
             || wincon::Console::stderr().is_ok();
-        LossyStandardStream { wtr: wtr, is_console: is_console }
+        LossyStandardStream { wtr, is_console }
     }
 
     #[cfg(not(windows))]
@@ -2113,7 +2112,7 @@ impl<W: io::Write> LossyStandardStream<W> {
 
     #[cfg(windows)]
     fn wrap<Q: io::Write>(&self, wtr: Q) -> LossyStandardStream<Q> {
-        LossyStandardStream { wtr: wtr, is_console: self.is_console }
+        LossyStandardStream { wtr, is_console: self.is_console }
     }
 
     fn get_ref(&self) -> &W {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1340,6 +1340,17 @@ impl<W: io::Write> io::Write for Ansi<W> {
         self.0.write(buf)
     }
 
+    // Adding this method here is not required because it has a default impl,
+    // but it seems to provide a perf improvement in some cases when using
+    // a `BufWriter` with lots of writes.
+    //
+    // See https://github.com/BurntSushi/termcolor/pull/56 for more details
+    // and a minimized example.
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()


### PR DESCRIPTION
And also do a few small cleanups. We keep the same MSRV mostly because there isn't any compelling reason to change it.