### PR TITLE
Update terminal tty checker recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ termcolor will inspect the `TERM` and `NO_COLOR` environment variables:
 This decision procedure may change over time.
 
 Currently, `termcolor` does not attempt to detect whether a tty is present or
-not. To achieve that, please use the [`atty`](https://crates.io/crates/atty)
+not. To achieve that, please use the [`is-terminal`](https://crates.io/crates/is-terminal)
 crate.
 
 ### Minimum Rust version policy


### PR DESCRIPTION
[atty](https://crates.io/crates/atty) has had a longstanding [security advisory](https://rustsec.org/advisories/RUSTSEC-2021-0145.html) that has not been resolved because the crate is unmaintained. This changes the recommendation to `is-terminal` which has merged the fixes and is maintained. 