### PR TITLE
Fine-tune the Ordering for printed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1143,7 +1143,7 @@ impl BufferWriter {
         }
         let mut stream = self.stream.wrap(self.stream.get_ref().lock());
         if let Some(ref sep) = self.separator {
-            if self.printed.load(Ordering::SeqCst) {
+            if self.printed.load(Ordering::Relaxed) {
                 stream.write_all(sep)?;
                 stream.write_all(b"\n")?;
             }
@@ -1163,7 +1163,7 @@ impl BufferWriter {
                 b.print(&mut *console, &mut stream)?;
             }
         }
-        self.printed.store(true, Ordering::SeqCst);
+        self.printed.store(true, Ordering::Relaxed);
         Ok(())
     }
 }


### PR DESCRIPTION
https://github.com/BurntSushi/termcolor/blob/e5f7a6c1fc3f3a0af5e2f6d281b72fa1dc223a0c/src/lib.rs#L1146
https://github.com/BurntSushi/termcolor/blob/e5f7a6c1fc3f3a0af5e2f6d281b72fa1dc223a0c/src/lib.rs#L1166
`Relaxed` is sufficient here as `printed` merely serves as an atomic signal in a multithreaded context, providing atomicity but not synchronization.