### PR TITLE
feat: support blinking text in ANSI mode.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1531,6 +1531,9 @@ impl<W: io::Write> WriteColor for Ansi<W> {
         if spec.underline {
             self.write_str("\x1B[4m")?;
         }
+        if spec.blink {
+            self.write_str("\x1B[5m")?;
+        }
         if spec.strikethrough {
             self.write_str("\x1B[9m")?;
         }
@@ -1833,6 +1836,7 @@ pub struct ColorSpec {
     italic: bool,
     reset: bool,
     strikethrough: bool,
+    blink: bool,
 }
 
 impl Default for ColorSpec {
@@ -1847,6 +1851,7 @@ impl Default for ColorSpec {
             italic: false,
             reset: true,
             strikethrough: false,
+            blink: false,
         }
     }
 }
@@ -1939,6 +1944,21 @@ impl ColorSpec {
         self
     }
 
+    /// Get whether this is blinking or not.
+    ///
+    /// Note that the blink setting has no effect in a Windows console.
+    pub fn blink(&self) -> bool {
+        self.blink
+    }
+
+    /// Set whether the text is blinking or not.
+    ///
+    /// Note that the blink setting has no effect in a Windows console.
+    pub fn set_blink(&mut self, yes: bool) -> &mut ColorSpec {
+        self.blink = yes;
+        self
+    }
+
     /// Get whether this is strikethrough or not.
     ///
     /// Note that the strikethrough setting has no effect in a Windows console.
@@ -2016,6 +2036,7 @@ impl ColorSpec {
             && !self.italic
             && !self.intense
             && !self.strikethrough
+            && !self.blink
     }
 
     /// Clears this color specification so that it has no color/style settings.
@@ -2028,6 +2049,7 @@ impl ColorSpec {
         self.dimmed = false;
         self.italic = false;
         self.strikethrough = false;
+        self.blink = false;
     }
 
     /// Writes this color spec to the given Windows console.
@@ -2513,16 +2535,21 @@ mod tests {
                             for italic in vec![false, true] {
                                 for strikethrough in vec![false, true] {
                                     for dimmed in vec![false, true] {
-                                        let mut color = ColorSpec::new();
-                                        color.set_fg(fg);
-                                        color.set_bg(bg);
-                                        color.set_bold(bold);
-                                        color.set_underline(underline);
-                                        color.set_intense(intense);
-                                        color.set_italic(italic);
-                                        color.set_dimmed(dimmed);
-                                        color.set_strikethrough(strikethrough);
-                                        result.push(color);
+                                        for blink in vec![false, true] {
+                                            let mut color = ColorSpec::new();
+                                            color.set_fg(fg);
+                                            color.set_bg(bg);
+                                            color.set_bold(bold);
+                                            color.set_underline(underline);
+                                            color.set_intense(intense);
+                                            color.set_italic(italic);
+                                            color.set_dimmed(dimmed);
+                                            color.set_strikethrough(
+                                                strikethrough,
+                                            );
+                                            color.set_blink(blink);
+                                            result.push(color);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Add blink support to termcolor in preparation for adding a blink text style to ripgrep for this enhancement request:

https://github.com/BurntSushi/ripgrep/issues/2930

Would you like me to bump the version to 1.5.0 in this PR?