### PR TITLE
ci: winapi-util has a MSRV of 1.72.0, change the pinned-win build to use that.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           rust: 1.60.0
         - build: pinned-win
           os: windows-latest
-          rust: 1.60.0
+          rust: 1.72.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.60.0
+          rust: 1.72.0
         - build: pinned-win
           os: windows-latest
           rust: 1.72.0

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ not. To achieve that, please use
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.34.0`.
+This crate's minimum supported `rustc` version is `1.72.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires


### PR DESCRIPTION

As of Sep 20, 2023, winapi-util bumped the minimum rust version to 1.72.0. Update the pinned windows build to that version.